### PR TITLE
Update AndroidAudio.java

### DIFF
--- a/ch06-mr-nom/ch06-mr-nom/app/src/main/java/com/badlogic/androidgames/framework/impl/AndroidAudio.java
+++ b/ch06-mr-nom/ch06-mr-nom/app/src/main/java/com/badlogic/androidgames/framework/impl/AndroidAudio.java
@@ -20,15 +20,18 @@ public class AndroidAudio implements Audio {
     public AndroidAudio(Activity activity) {
         activity.setVolumeControlStream(AudioManager.STREAM_MUSIC);
         this.assets = activity.getAssets();
-        AudioAttributes audioAttributes = new AudioAttributes.Builder()
-                .setUsage(AudioAttributes.USAGE_GAME)
-                .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                .build();
-
-        this.soundPool = new SoundPool.Builder()
-                .setMaxStreams(20)
-                .setAudioAttributes(audioAttributes)
-                .build();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            AudioAttributes audioAttributes = new AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_GAME)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                    .build();
+            this.soundPool = new SoundPool.Builder()
+                    .setMaxStreams(20)
+                    .setAudioAttributes(audioAttributes)
+                    .build();
+        } else {
+            this.soundPool = new SoundPool(20, AudioManager.STREAM_MUSIC, 1);
+        }
     }
 
     public Music newMusic(String filename) {


### PR DESCRIPTION
I modified the creation of the SoundPool for it to use the deprecated constructor if the app is being run on an API under 21. Currently, if you are running Android KitKat, the code will not run on your device as `AudioAttributes` only runs on API level 21 and over.

Seeing that the `SoundPool` constructor was only deprecated because it was unclear I think that it is safe to allow users running an API below 21 to be able to run the deprecated constructor.